### PR TITLE
first stab at boilerplate, for existing claims

### DIFF
--- a/chart/README.md
+++ b/chart/README.md
@@ -36,6 +36,57 @@ An example PV might look something like the following:
       path: /mnt/mysql
 ```
 
+### Existing PersistentVolumeClaims
+
+1. Create the PersistentVolume
+```bash
+$ cat <<EOT | kubectl create -f -
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: test
+  labels:
+    volume_name: test
+spec:
+  capacity:
+    storage: 2Gi
+  accessModes:
+    - ReadWriteOnce
+  nfs:
+    server: nfs.example.com
+    path: "/test"
+  persistentVolumeReclaimPolicy: Retain
+EOT
+```
+1. Create the PersistentVolumeClaim
+```bash
+$ cat <<EOT | kubectl create -f -
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: test
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  selector:
+    matchLabels:
+      volume_name: test
+EOT
+```
+1. Create the directory, on a worker
+```bash
+# mkdir -m 1777 /NFS_MOUNT/test
+```
+1. Install the chart
+```bash
+$ helm install --name test --set Persistence.existingClaim=test .
+```
+
 ## Usage
 
 // Todo: Write up usage.

--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -14,3 +14,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this
 {{- $name := default "__CHART__" .Values.nameOverride -}}
 {{printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{end}}
+
+{{/*
+Provide a pre-defined claim or a claim based on the Release
+*/}}
+{{- define "__CHART__.pvcName" -}}
+{{- if .Values.Persistence.existingClaim }}
+{{- .Values.Persistence.existingClaim }}
+{{- else -}}
+{{- template "__CHART__.fullname" . }}
+{{- end -}}
+{{- end -}}
+

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
       ##
       #   - name: "__VOLUME_NAME__"
       #     persistentVolumeClaim:
-      #       claimName: "__CLAIM_NAME__"
+      #       claimName: {{ template "__CHART__.pvcName" . }}
       ##
       ## CONFIGMAP
       ##

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.Persistence.existingClaim }}
 ---
 kind: "PersistentVolumeClaim"
 apiVersion: "v1"
@@ -15,3 +16,4 @@ spec:
   resources:
     requests:
       storage: {{ .Values.Persistence.Size | quote }}
+{{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,6 +59,7 @@ Resources:
 
 Persistence:
   Size: "10gb"
+  # existingClaim:
   # storageClass:
 
 ## Configuration to enable the easy provisioning of certificates with kube-cert-manager and a Boulder compatible CA


### PR DESCRIPTION
Add `Persistence.existingClaim` and `__CHART__.pvcName` template, for environments which do not use dynamic PV/PVC.